### PR TITLE
Update transport.xml to take correct zone goal.

### DIFF
--- a/plansys2_bt_example/behavior_trees_xml/transport.xml
+++ b/plansys2_bt_example/behavior_trees_xml/transport.xml
@@ -4,7 +4,7 @@
            <OpenGripper    name="open_gripper"/>
            <ApproachObject name="approach_object"/>
            <CloseGripper   name="close_gripper"/>
-           <Move    name="move" goal="${arg2}"/>
+           <Move    name="move" goal="${arg3}"/>
            <OpenGripper    name="open_gripper"/>
        </Sequence>
     </BehaviorTree>


### PR DESCRIPTION
Current example does not return to the assembly zone as intended because it's being passed the current zone the robot is in as the Move goal. Updating to deliver piece to intended zone.