### PR TITLE
Fix typos in bt_example.pddl and simple_example.pddl.

### DIFF
--- a/plansys2_bt_example/pddl/bt_example.pddl
+++ b/plansys2_bt_example/pddl/bt_example.pddl
@@ -21,7 +21,7 @@ car
 
 (piece_is_wheel ?p - piece)
 (piece_is_body_car ?p - piece)
-(piece_is_sterwheel ?p - piece)
+(piece_is_steering_wheel ?p - piece)
 
 (piece_not_used ?p - piece)
 

--- a/plansys2_simple_example/pddl/simple_example.pddl
+++ b/plansys2_simple_example/pddl/simple_example.pddl
@@ -45,7 +45,7 @@ room
        )
     :effect (and
         (at start(not(robot_at ?r ?r1)))
-        (at start(robot_at ?r ?r2))
+        (at end(robot_at ?r ?r2))
     )
 )
 


### PR DESCRIPTION
Typo in bt_example.pddl returned an error when the predicate piece_is_sterwheel was added, but the [tutorial](https://intelligentroboticslab.gsyc.urjc.es/ros2_planning_system.github.io/tutorials/docs/bt_actions.html) says to add `set predicate (piece_is_steering_wheel steering_wheel_1)` to the kb.

Correction made to simple_example.pddl, which had a robot_at r2 effect "at start" instead of "at end".