### PR TITLE
Pass plan to executor

### DIFF
--- a/plansys2_bt_example/CMakeLists.txt
+++ b/plansys2_bt_example/CMakeLists.txt
@@ -9,7 +9,11 @@ find_package(geometry_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(plansys2_msgs REQUIRED)
+find_package(plansys2_domain_expert REQUIRED)
 find_package(plansys2_executor REQUIRED)
+find_package(plansys2_planner REQUIRED)
+find_package(plansys2_problem_expert REQUIRED)
+find_package(plansys2_pddl_parser REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(plansys2_bt_actions REQUIRED)
 
@@ -24,7 +28,11 @@ set(dependencies
     tf2_geometry_msgs
     nav2_msgs
     plansys2_msgs
+    plansys2_domain_expert
     plansys2_executor
+    plansys2_planner
+    plansys2_problem_expert
+    plansys2_pddl_parser
     ament_index_cpp
     plansys2_bt_actions
 )

--- a/plansys2_bt_example/package.xml
+++ b/plansys2_bt_example/package.xml
@@ -18,7 +18,11 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>nav2_msgs</depend>
   <depend>plansys2_msgs</depend>
+  <depend>plansys2_domain_expert</depend>
   <depend>plansys2_executor</depend>
+  <depend>plansys2_planner</depend>
+  <depend>plansys2_problem_expert</depend>
+  <depend>plansys2_pddl_parser</depend>
   <depend>ament_index_cpp</depend>
   <depend>plansys2_bt_actions</depend>
 

--- a/plansys2_bt_example/src/assemble_controller_node.cpp
+++ b/plansys2_bt_example/src/assemble_controller_node.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <plansys2_pddl_parser/Utils.h>
+
 #include <memory>
 
 #include "plansys2_msgs/msg/action_execution_info.hpp"
@@ -21,7 +23,6 @@
 #include "plansys2_executor/ExecutorClient.hpp"
 #include "plansys2_planner/PlannerClient.hpp"
 #include "plansys2_problem_expert/ProblemExpertClient.hpp"
-#include <plansys2_pddl_parser/Utils.h>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"

--- a/plansys2_bt_example/src/assemble_controller_node.cpp
+++ b/plansys2_bt_example/src/assemble_controller_node.cpp
@@ -15,9 +15,13 @@
 #include <memory>
 
 #include "plansys2_msgs/msg/action_execution_info.hpp"
+#include "plansys2_msgs/msg/plan.hpp"
 
+#include "plansys2_domain_expert/DomainExpertClient.hpp"
 #include "plansys2_executor/ExecutorClient.hpp"
+#include "plansys2_planner/PlannerClient.hpp"
 #include "plansys2_problem_expert/ProblemExpertClient.hpp"
+#include <plansys2_pddl_parser/Utils.h>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
@@ -30,16 +34,30 @@ public:
   {
   }
 
-  void init()
+  bool init()
   {
+    domain_expert_ = std::make_shared<plansys2::DomainExpertClient>(shared_from_this());
+    planner_client_ = std::make_shared<plansys2::PlannerClient>(shared_from_this());
     problem_expert_ = std::make_shared<plansys2::ProblemExpertClient>(shared_from_this());
     executor_client_ = std::make_shared<plansys2::ExecutorClient>(shared_from_this());
 
     init_knowledge();
 
-    if (!executor_client_->start_plan_execution()) {
+    auto domain = domain_expert_->getDomain();
+    auto problem = problem_expert_->getProblem();
+    auto plan = planner_client_->getPlan(domain, problem);
+
+    if (!plan.has_value()) {
+      std::cout << "Could not find plan to reach goal " <<
+        parser::pddl::toString(problem_expert_->getGoal()) << std::endl;
+      return false;
+    }
+
+    if (!executor_client_->start_plan_execution(plan.value())) {
       RCLCPP_ERROR(get_logger(), "Error starting a new plan (first)");
     }
+
+    return true;
   }
 
   void init_knowledge()
@@ -129,6 +147,8 @@ public:
   }
 
 private:
+  std::shared_ptr<plansys2::DomainExpertClient> domain_expert_;
+  std::shared_ptr<plansys2::PlannerClient> planner_client_;
   std::shared_ptr<plansys2::ProblemExpertClient> problem_expert_;
   std::shared_ptr<plansys2::ExecutorClient> executor_client_;
 };
@@ -138,7 +158,9 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
   auto node = std::make_shared<Assemble>();
 
-  node->init();
+  if (!node->init()) {
+    return 0;
+  }
 
   rclcpp::Rate rate(5);
   while (rclcpp::ok()) {

--- a/plansys2_patrol_navigation_example/CMakeLists.txt
+++ b/plansys2_patrol_navigation_example/CMakeLists.txt
@@ -8,8 +8,11 @@ find_package(rclcpp_action REQUIRED)
 find_package(plansys2_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
-find_package(plansys2_executor REQUIRED)
 find_package(plansys2_domain_expert REQUIRED)
+find_package(plansys2_executor REQUIRED)
+find_package(plansys2_planner REQUIRED)
+find_package(plansys2_problem_expert REQUIRED)
+find_package(plansys2_pddl_parser REQUIRED)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -18,9 +21,11 @@ set(dependencies
     rclcpp_action
     plansys2_msgs
     nav2_msgs
-    plansys2_executor
-    plansys2_problem_expert
     plansys2_domain_expert
+    plansys2_executor
+    plansys2_planner
+    plansys2_problem_expert
+    plansys2_pddl_parser
 )
 
 add_executable(move_action_node src/move_action_node.cpp)

--- a/plansys2_patrol_navigation_example/package.xml
+++ b/plansys2_patrol_navigation_example/package.xml
@@ -17,9 +17,11 @@
   <depend>plansys2_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>nav2_msgs</depend>
-  <depend>plansys2_executor</depend>
-  <depend>plansys2_problem_expert</depend>
   <depend>plansys2_domain_expert</depend>
+  <depend>plansys2_executor</depend>
+  <depend>plansys2_planner</depend>
+  <depend>plansys2_problem_expert</depend>
+  <depend>plansys2_pddl_parser</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/plansys2_patrol_navigation_example/src/patrolling_controller_node.cpp
+++ b/plansys2_patrol_navigation_example/src/patrolling_controller_node.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <plansys2_pddl_parser/Utils.h>
+
 #include <memory>
 
 #include "plansys2_msgs/msg/action_execution_info.hpp"
@@ -21,7 +23,6 @@
 #include "plansys2_executor/ExecutorClient.hpp"
 #include "plansys2_planner/PlannerClient.hpp"
 #include "plansys2_problem_expert/ProblemExpertClient.hpp"
-#include <plansys2_pddl_parser/Utils.h>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
@@ -172,7 +173,6 @@ public:
               auto domain = domain_expert_->getDomain();
               auto problem = problem_expert_->getProblem();
               auto plan = planner_client_->getPlan(domain, problem);
-              std::cout << problem << std::endl;
 
               if (!plan.has_value()) {
                 std::cout << "Could not find plan to reach goal " <<

--- a/plansys2_patrol_navigation_example/src/patrolling_controller_node.cpp
+++ b/plansys2_patrol_navigation_example/src/patrolling_controller_node.cpp
@@ -15,9 +15,13 @@
 #include <memory>
 
 #include "plansys2_msgs/msg/action_execution_info.hpp"
+#include "plansys2_msgs/msg/plan.hpp"
 
+#include "plansys2_domain_expert/DomainExpertClient.hpp"
 #include "plansys2_executor/ExecutorClient.hpp"
+#include "plansys2_planner/PlannerClient.hpp"
 #include "plansys2_problem_expert/ProblemExpertClient.hpp"
+#include <plansys2_pddl_parser/Utils.h>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
@@ -32,6 +36,8 @@ public:
 
   void init()
   {
+    domain_expert_ = std::make_shared<plansys2::DomainExpertClient>(shared_from_this());
+    planner_client_ = std::make_shared<plansys2::PlannerClient>(shared_from_this());
     problem_expert_ = std::make_shared<plansys2::ProblemExpertClient>(shared_from_this());
     executor_client_ = std::make_shared<plansys2::ExecutorClient>(shared_from_this());
     init_knowledge();
@@ -61,11 +67,25 @@ public:
   {
     switch (state_) {
       case STARTING:
-        // Set the goal for next state, and execute plan
-        problem_expert_->setGoal(plansys2::Goal("(and(patrolled wp1))"));
+        {
+          // Set the goal for next state
+          problem_expert_->setGoal(plansys2::Goal("(and(patrolled wp1))"));
 
-        if (executor_client_->start_plan_execution()) {
-          state_ = PATROL_WP1;
+          // Compute the plan
+          auto domain = domain_expert_->getDomain();
+          auto problem = problem_expert_->getProblem();
+          auto plan = planner_client_->getPlan(domain, problem);
+
+          if (!plan.has_value()) {
+            std::cout << "Could not find plan to reach goal " <<
+              parser::pddl::toString(problem_expert_->getGoal()) << std::endl;
+            break;
+          }
+
+          // Execute the plan
+          if (executor_client_->start_plan_execution(plan.value())) {
+            state_ = PATROL_WP1;
+          }
         }
         break;
       case PATROL_WP1:
@@ -85,10 +105,22 @@ public:
               // Cleanning up
               problem_expert_->removePredicate(plansys2::Predicate("(patrolled wp1)"));
 
-              // Set the goal for next state, and execute plan
+              // Set the goal for next state
               problem_expert_->setGoal(plansys2::Goal("(and(patrolled wp2))"));
 
-              if (executor_client_->start_plan_execution()) {
+              // Compute the plan
+              auto domain = domain_expert_->getDomain();
+              auto problem = problem_expert_->getProblem();
+              auto plan = planner_client_->getPlan(domain, problem);
+
+              if (!plan.has_value()) {
+                std::cout << "Could not find plan to reach goal " <<
+                  parser::pddl::toString(problem_expert_->getGoal()) << std::endl;
+                break;
+              }
+
+              // Execute the plan
+              if (executor_client_->start_plan_execution(plan.value())) {
                 state_ = PATROL_WP2;
               }
             } else {
@@ -98,7 +130,20 @@ public:
                     action_feedback.message_status << std::endl;
                 }
               }
-              executor_client_->start_plan_execution();  // replan and execute
+
+              // Replan
+              auto domain = domain_expert_->getDomain();
+              auto problem = problem_expert_->getProblem();
+              auto plan = planner_client_->getPlan(domain, problem);
+
+              if (!plan.has_value()) {
+                std::cout << "Unsuccessful replan attempt to reach goal " <<
+                  parser::pddl::toString(problem_expert_->getGoal()) << std::endl;
+                break;
+              }
+
+              // Execute the plan
+              executor_client_->start_plan_execution(plan.value());
             }
           }
         }
@@ -120,10 +165,23 @@ public:
               // Cleanning up
               problem_expert_->removePredicate(plansys2::Predicate("(patrolled wp2)"));
 
-              // Set the goal for next state, and execute plan
+              // Set the goal for next state
               problem_expert_->setGoal(plansys2::Goal("(and(patrolled wp3))"));
 
-              if (executor_client_->start_plan_execution()) {
+              // Compute the plan
+              auto domain = domain_expert_->getDomain();
+              auto problem = problem_expert_->getProblem();
+              auto plan = planner_client_->getPlan(domain, problem);
+              std::cout << problem << std::endl;
+
+              if (!plan.has_value()) {
+                std::cout << "Could not find plan to reach goal " <<
+                  parser::pddl::toString(problem_expert_->getGoal()) << std::endl;
+                break;
+              }
+
+              // Execute the plan
+              if (executor_client_->start_plan_execution(plan.value())) {
                 state_ = PATROL_WP3;
               }
             } else {
@@ -133,7 +191,20 @@ public:
                     action_feedback.message_status << std::endl;
                 }
               }
-              executor_client_->start_plan_execution();  // replan and execute
+
+              // Replan
+              auto domain = domain_expert_->getDomain();
+              auto problem = problem_expert_->getProblem();
+              auto plan = planner_client_->getPlan(domain, problem);
+
+              if (!plan.has_value()) {
+                std::cout << "Unsuccessful replan attempt to reach goal " <<
+                  parser::pddl::toString(problem_expert_->getGoal()) << std::endl;
+                break;
+              }
+
+              // Execute the plan
+              executor_client_->start_plan_execution(plan.value());
             }
           }
         }
@@ -155,10 +226,22 @@ public:
               // Cleanning up
               problem_expert_->removePredicate(plansys2::Predicate("(patrolled wp3)"));
 
-              // Set the goal for next state, and execute plan
+              // Set the goal for next state
               problem_expert_->setGoal(plansys2::Goal("(and(patrolled wp4))"));
 
-              if (executor_client_->start_plan_execution()) {
+              // Compute the plan
+              auto domain = domain_expert_->getDomain();
+              auto problem = problem_expert_->getProblem();
+              auto plan = planner_client_->getPlan(domain, problem);
+
+              if (!plan.has_value()) {
+                std::cout << "Could not find plan to reach goal " <<
+                  parser::pddl::toString(problem_expert_->getGoal()) << std::endl;
+                break;
+              }
+
+              // Execute the plan
+              if (executor_client_->start_plan_execution(plan.value())) {
                 state_ = PATROL_WP4;
               }
             } else {
@@ -168,7 +251,20 @@ public:
                     action_feedback.message_status << std::endl;
                 }
               }
-              executor_client_->start_plan_execution();  // replan and execute
+
+              // Replan
+              auto domain = domain_expert_->getDomain();
+              auto problem = problem_expert_->getProblem();
+              auto plan = planner_client_->getPlan(domain, problem);
+
+              if (!plan.has_value()) {
+                std::cout << "Unsuccessful replan attempt to reach goal " <<
+                  parser::pddl::toString(problem_expert_->getGoal()) << std::endl;
+                break;
+              }
+
+              // Execute the plan
+              executor_client_->start_plan_execution(plan.value());
             }
           }
         }
@@ -190,10 +286,22 @@ public:
               // Cleanning up
               problem_expert_->removePredicate(plansys2::Predicate("(patrolled wp4)"));
 
-              // Set the goal for next state, and execute plan
+              // Set the goal for next state
               problem_expert_->setGoal(plansys2::Goal("(and(patrolled wp1))"));
 
-              if (executor_client_->start_plan_execution()) {
+              // Compute the plan
+              auto domain = domain_expert_->getDomain();
+              auto problem = problem_expert_->getProblem();
+              auto plan = planner_client_->getPlan(domain, problem);
+
+              if (!plan.has_value()) {
+                std::cout << "Could not find plan to reach goal " <<
+                  parser::pddl::toString(problem_expert_->getGoal()) << std::endl;
+                break;
+              }
+
+              // Execute the plan
+              if (executor_client_->start_plan_execution(plan.value())) {
                 // Loop to WP1
                 state_ = PATROL_WP1;
               }
@@ -204,7 +312,20 @@ public:
                     action_feedback.message_status << std::endl;
                 }
               }
-              executor_client_->start_plan_execution();  // replan and execute
+
+              // Replan
+              auto domain = domain_expert_->getDomain();
+              auto problem = problem_expert_->getProblem();
+              auto plan = planner_client_->getPlan(domain, problem);
+
+              if (!plan.has_value()) {
+                std::cout << "Unsuccessful replan attempt to reach goal " <<
+                  parser::pddl::toString(problem_expert_->getGoal()) << std::endl;
+                break;
+              }
+
+              // Execute the plan
+              executor_client_->start_plan_execution(plan.value());
             }
           }
         }
@@ -218,6 +339,8 @@ private:
   typedef enum {STARTING, PATROL_WP1, PATROL_WP2, PATROL_WP3, PATROL_WP4} StateType;
   StateType state_;
 
+  std::shared_ptr<plansys2::DomainExpertClient> domain_expert_;
+  std::shared_ptr<plansys2::PlannerClient> planner_client_;
   std::shared_ptr<plansys2::ProblemExpertClient> problem_expert_;
   std::shared_ptr<plansys2::ExecutorClient> executor_client_;
 };

--- a/plansys2_patrol_navigation_example/src/patrolling_controller_node.cpp
+++ b/plansys2_patrol_navigation_example/src/patrolling_controller_node.cpp
@@ -99,7 +99,7 @@ public:
           }
           std::cout << std::endl;
 
-          if (executor_client_->execute_and_check_plan() && executor_client_->getResult()) {
+          if (!executor_client_->execute_and_check_plan() && executor_client_->getResult()) {
             if (executor_client_->getResult().value().success) {
               std::cout << "Successful finished " << std::endl;
 
@@ -159,7 +159,7 @@ public:
           }
           std::cout << std::endl;
 
-          if (executor_client_->execute_and_check_plan() && executor_client_->getResult()) {
+          if (!executor_client_->execute_and_check_plan() && executor_client_->getResult()) {
             if (executor_client_->getResult().value().success) {
               std::cout << "Successful finished " << std::endl;
 
@@ -219,7 +219,7 @@ public:
           }
           std::cout << std::endl;
 
-          if (executor_client_->execute_and_check_plan() && executor_client_->getResult()) {
+          if (!executor_client_->execute_and_check_plan() && executor_client_->getResult()) {
             if (executor_client_->getResult().value().success) {
               std::cout << "Successful finished " << std::endl;
 
@@ -279,7 +279,7 @@ public:
           }
           std::cout << std::endl;
 
-          if (executor_client_->execute_and_check_plan() && executor_client_->getResult()) {
+          if (!executor_client_->execute_and_check_plan() && executor_client_->getResult()) {
             if (executor_client_->getResult().value().success) {
               std::cout << "Successful finished " << std::endl;
 


### PR DESCRIPTION
This PR updates the examples to work with the recent changes to PlanSys2 in PR #131. Specifically, the plan is now passed into the executor rather than being computed within the executor. A bug was also found and fixed (credit goes to @xydesa) in the patrol navigation example. In a previous refactoring effort, the execute_and_check_plan function was modified to return false to indicate done. However, this example was not updated for that change.