### PR TITLE
Fix mismatched predicate piece_is_steering_wheel

### DIFF
--- a/plansys2_bt_example/pddl/bt_example.pddl
+++ b/plansys2_bt_example/pddl/bt_example.pddl
@@ -104,7 +104,7 @@ car
 
         (at start(piece_is_wheel ?p1))
         (at start(piece_is_body_car ?p2))
-        (at start(piece_is_sterwheel ?p3))
+        (at start(piece_is_steering_wheel ?p3))
         (at start(robot_available ?r))
     )
     :effect (and


### PR DESCRIPTION
The at start condition in action assemble had a condition "piece_is_sterwheel", causing an error since the predicate definition is spelled with "piece_is_steering_wheel".