### PR TITLE
Fix predicate in PDDL domain

### DIFF
--- a/plansys2_bt_example/pddl/bt_example.pddl
+++ b/plansys2_bt_example/pddl/bt_example.pddl
@@ -104,7 +104,7 @@ car
 
         (at start(piece_is_wheel ?p1))
         (at start(piece_is_body_car ?p2))
-        (at start(piece_is_sterwheel ?p3))
+        (at start(piece_is_steering_wheel ?p3))
         (at start(robot_available ?r))
     )
     :effect (and


### PR DESCRIPTION
Hi,

This PR fixes a bug in the pddl in the BT example. This has been notified in https://github.com/IntelligentRoboticsLabs/ros2_planning_system/issues/142.

Best

Signed-off-by: Francisco Martín Rico <fmrico@gmail.com>