### PR TITLE
Ignore parameter redeclaration

### DIFF
--- a/plansys2_bt_example/src/behavior_tree_nodes/Move.cpp
+++ b/plansys2_bt_example/src/behavior_tree_nodes/Move.cpp
@@ -38,8 +38,12 @@ Move::Move(
   rclcpp::Node::SharedPtr node;
   config().blackboard->get("node", node);
 
-  node->declare_parameter("waypoints");
-  node->declare_parameter("waypoint_coords");
+  try {
+    node->declare_parameter("waypoints");
+    node->declare_parameter("waypoint_coords");
+  } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException & e) {
+    // Do nothing;
+  }
 
   if (node->has_parameter("waypoints")) {
     std::vector<std::string> wp_names;
@@ -47,7 +51,11 @@ Move::Move(
     node->get_parameter_or("waypoints", wp_names, {});
 
     for (auto & wp : wp_names) {
-      node->declare_parameter("waypoint_coords." + wp);
+      try {
+        node->declare_parameter("waypoint_coords." + wp);
+      } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException & e) {
+        // Do nothing;
+      }
 
       std::vector<double> coords;
       if (node->get_parameter_or("waypoint_coords." + wp, coords, {})) {


### PR DESCRIPTION
Dear PlanSys2 users and developers

From Galactic, parameter redeclaration seems to raise an exception. This PR contains a change that manages the exception to ignore it, fixing https://github.com/IntelligentRoboticsLabs/ros2_planning_system_examples/issues/24

I hope it helps!!


Signed-off-by: Francisco Martín Rico <fmrico@gmail.com>