### PR TITLE
Add missing exec_depends to all examples

### DIFF
--- a/plansys2_bt_example/package.xml
+++ b/plansys2_bt_example/package.xml
@@ -27,6 +27,7 @@
   <depend>plansys2_bt_actions</depend>
 
   <exec_depend>plansys2_bringup</exec_depend>
+  <exec_depend>plansys2_terminal</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/plansys2_bt_example/package.xml
+++ b/plansys2_bt_example/package.xml
@@ -3,11 +3,11 @@
 <package format="3">
   <name>plansys2_bt_example</name>
   <version>0.0.4</version>
-  
+
   <description>A simple example of ROS2 Planning System</description>
 
   <maintainer email="fmrico@gmail.com">Francisco Martin Rico</maintainer>
- 
+
   <license>Apache License, Version 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
@@ -25,6 +25,8 @@
   <depend>plansys2_pddl_parser</depend>
   <depend>ament_index_cpp</depend>
   <depend>plansys2_bt_actions</depend>
+
+  <exec_depend>plansys2_bringup</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/plansys2_cascade_example/package.xml
+++ b/plansys2_cascade_example/package.xml
@@ -18,6 +18,7 @@
   <depend>plansys2_executor</depend>
 
   <exec_depend>plansys2_bringup</exec_depend>
+  <exec_depend>plansys2_terminal</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/plansys2_cascade_example/package.xml
+++ b/plansys2_cascade_example/package.xml
@@ -3,11 +3,11 @@
 <package format="3">
   <name>plansys2_cascade_example</name>
   <version>0.0.4</version>
-  
+
   <description>A cascade example of ROS2 Planning System</description>
 
   <maintainer email="fmrico@gmail.com">Francisco Martin Rico</maintainer>
- 
+
   <license>Apache License, Version 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
@@ -16,6 +16,8 @@
   <depend>rclcpp_action</depend>
   <depend>plansys2_msgs</depend>
   <depend>plansys2_executor</depend>
+
+  <exec_depend>plansys2_bringup</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/plansys2_multidomain_example/package.xml
+++ b/plansys2_multidomain_example/package.xml
@@ -18,6 +18,7 @@
   <depend>plansys2_executor</depend>
 
   <exec_depend>plansys2_bringup</exec_depend>
+  <exec_depend>plansys2_terminal</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/plansys2_multidomain_example/package.xml
+++ b/plansys2_multidomain_example/package.xml
@@ -3,11 +3,11 @@
 <package format="3">
   <name>plansys2_multidomain_example</name>
   <version>0.0.4</version>
-  
+
   <description>A simple example of ROS2 Planning System</description>
 
   <maintainer email="fmrico@gmail.com">Francisco Martin Rico</maintainer>
- 
+
   <license>Apache License, Version 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
@@ -16,6 +16,8 @@
   <depend>rclcpp_action</depend>
   <depend>plansys2_msgs</depend>
   <depend>plansys2_executor</depend>
+
+  <exec_depend>plansys2_bringup</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/plansys2_patrol_navigation_example/package.xml
+++ b/plansys2_patrol_navigation_example/package.xml
@@ -3,11 +3,11 @@
 <package format="3">
   <name>plansys2_patrol_navigation_example</name>
   <version>0.0.4</version>
-  
+
   <description>An example including Navigation</description>
 
   <maintainer email="fmrico@gmail.com">Francisco Martin Rico</maintainer>
- 
+
   <license>Apache License, Version 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
@@ -22,6 +22,8 @@
   <depend>plansys2_planner</depend>
   <depend>plansys2_problem_expert</depend>
   <depend>plansys2_pddl_parser</depend>
+
+  <exec_depend>plansys2_bringup</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/plansys2_patrol_navigation_example/package.xml
+++ b/plansys2_patrol_navigation_example/package.xml
@@ -24,6 +24,7 @@
   <depend>plansys2_pddl_parser</depend>
 
   <exec_depend>plansys2_bringup</exec_depend>
+  <exec_depend>plansys2_terminal</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/plansys2_simple_example/package.xml
+++ b/plansys2_simple_example/package.xml
@@ -18,6 +18,7 @@
   <depend>plansys2_executor</depend>
 
   <exec_depend>plansys2_bringup</exec_depend>
+  <exec_depend>plansys2_terminal</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/plansys2_simple_example/package.xml
+++ b/plansys2_simple_example/package.xml
@@ -3,11 +3,11 @@
 <package format="3">
   <name>plansys2_simple_example</name>
   <version>0.0.4</version>
-  
+
   <description>A simple example of ROS2 Planning System</description>
 
   <maintainer email="fmrico@gmail.com">Francisco Martin Rico</maintainer>
- 
+
   <license>Apache License, Version 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
@@ -16,6 +16,8 @@
   <depend>rclcpp_action</depend>
   <depend>plansys2_msgs</depend>
   <depend>plansys2_executor</depend>
+
+  <exec_depend>plansys2_bringup</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Howdy,

This is a simple PR that adds `plansys2_bringup` as an `<exec_depends>` to all of the examples.

Whoops, added `plansys2_terminal` as well.

For reference, I ran into this issue by:

1. running it in an environment without any of the `ros-foxy-plansys2-*` packages installed
2. cloned this `ros2_planning_system_examples` repo
3. did `rosdep install` to grab dependencies
4. attempted to run the [simple example](https://github.com/IntelligentRoboticsLabs/ros2_planning_system_examples/tree/master/plansys2_simple_example) tutorial
5. ran into missing `plansys2_bringup` and `plansys2_terminal` errors